### PR TITLE
chore: stop matching multi-sink q on non-fallback nodes after switch

### DIFF
--- a/mama-module/java-cep/src/main/java/com/huberlin/PatternFactory_generic.java
+++ b/mama-module/java-cep/src/main/java/com/huberlin/PatternFactory_generic.java
@@ -209,9 +209,39 @@ public class PatternFactory_generic {
     Pattern<Event, Event> p =
         Pattern.<Event>begin(firstPatternName)
             .where(checkEventTypeFirst(firstEventType, firstPatternName)) // get first event type
+            .where(
+                new SimpleCondition<Event>() {
+                  @Override
+                  public boolean filter(Event e) {
+                    boolean isMultiSinkQuery =
+                        q.queryName.equals(config.rateMonitoringInputs.multiSinkQuery);
+                    boolean isNonFallbackNode =
+                        config.rateMonitoringInputs.multiSinkNodes.contains(config.nodeId)
+                            && (config.rateMonitoringInputs.fallbackNode != config.nodeId);
+                    if (isMultiSinkQuery && isNonFallbackNode && !e.multiSinkQueryEnabled) {
+                      return false;
+                    }
+                    return true;
+                  }
+                })
             .followedByAny(secondPatternName)
             .where(
                 checkEventTypeSecond(secondEventType, secondPatternName)) // get second event type
+            .where(
+                new SimpleCondition<Event>() {
+                  @Override
+                  public boolean filter(Event e) {
+                    boolean isMultiSinkQuery =
+                        q.queryName.equals(config.rateMonitoringInputs.multiSinkQuery);
+                    boolean isNonFallbackNode =
+                        config.rateMonitoringInputs.multiSinkNodes.contains(config.nodeId)
+                            && (config.rateMonitoringInputs.fallbackNode != config.nodeId);
+                    if (isMultiSinkQuery && isNonFallbackNode && !e.multiSinkQueryEnabled) {
+                      return false;
+                    }
+                    return true;
+                  }
+                })
             .where(
                 new IterativeCondition<Event>() { // Check timestamps, sequence and id constraints
                   long seed = 12345L;

--- a/mama-module/java-cep/src/main/java/com/huberlin/ScheduledTask.java
+++ b/mama-module/java-cep/src/main/java/com/huberlin/ScheduledTask.java
@@ -149,9 +149,10 @@ public class ScheduledTask implements Runnable {
     LOG.info("Forwarding table updated successfully");
     LOG.info("Forwarding table after update: {}", this.fwdTableRef.get().toString());
     LOG.info(
-        "===============FLUSHING BUFFERED PARTITIONING INPUTS OF SIZE:" + " {}===============",
-        this.eventBuffer.size());
-    LOG.info(this.eventBuffer.toString());
+        "FLUSHING BUFFERED PARTITIONING INPUTS OF SIZE: {}. Buffer: {}",
+        this.eventBuffer.size(),
+        this.eventBuffer.toString());
+    // LOG.info(this.eventBuffer.toString());
 
     try {
       assert (this.eventBuffer.stream()


### PR DESCRIPTION
Extends #3 